### PR TITLE
Create new data_names_v03.yaml

### DIFF
--- a/cure_ground/core/protocols/data_names/data_names_v03.yaml
+++ b/cure_ground/core/protocols/data_names/data_names_v03.yaml
@@ -16,19 +16,11 @@ data_names:
     unit: "°/s"
     data:
       - name: GYROSCOPE_X
-        id: 0
+        id: 3
       - name: GYROSCOPE_Y
-        id: 1
+        id: 4
       - name: GYROSCOPE_Z
-        id: 2
-  - type: single
-    name: ALTITUDE
-    id: 8
-    unit: "m"
-  - type: single
-    name: EST_ALTITUDE
-    id: 19
-    unit: "m"
+        id: 5
   - type: single
     name: TEMPERATURE
     id: 6
@@ -37,6 +29,10 @@ data_names:
     name: PRESSURE
     id: 7
     unit: "hPa"
+  - type: single
+    name: ALTITUDE
+    id: 8
+    unit: "m"
   - type: group
     name: MAGNETOMETER
     id: 111
@@ -49,18 +45,46 @@ data_names:
       - name: MAGNETOMETER_Z
         id: 11
   - type: single
+    name: MEDIAN_ACCELERATION_SQUARED
+    id: 12
+    unit: "m²/s²"
+  - type: single
     name: CYCLE_RATE
     id: 13
     unit: "Hz"
+  - type: single
+    name: TIMESTAMP
+    id: 14
+    unit: "s"
   - type: single
     name: STATE_CHANGE
     id: 15
     unit: "enum"
   - type: single
+    name: FLIGHT_ID
+    id: 16
+    unit: "id"
+  - type: single
+    name: EST_APOGEE
+    id: 17
+    unit: "m"
+  - type: single
+    name: EST_VERTICAL_VELOCITY
+    id: 18
+    unit: "m/s"
+  - type: single
+    name: EST_ALTITUDE
+    id: 19
+    unit: "m"
+  - type: single
     name: BATT
     id: 20
     unit: "V"
   - type: single
-    name: FLIGHT_ID
-    id: 16
-    unit: "id"
+    name: FIN_DEPLOYMENT_AMOUNT
+    id: 21
+    unit: "°"
+  - type: single
+    name: TIME_TO_APOGEE
+    id: 22
+    unit: "s"

--- a/cure_ground/core/protocols/data_names/data_names_v03.yaml
+++ b/cure_ground/core/protocols/data_names/data_names_v03.yaml
@@ -1,0 +1,66 @@
+data_names:
+  - type: group
+    name: ACCELEROMETER
+    id: 102
+    unit: "m/s²"
+    data:
+      - name: ACCELEROMETER_X
+        id: 0
+      - name: ACCELEROMETER_Y
+        id: 1
+      - name: ACCELEROMETER_Z
+        id: 2
+  - type: group
+    name: ACCELEROMETGYROSCOPE_XER
+    id: 105
+    unit: "°/s"
+    data:
+      - name: GYROSCOPE_X
+        id: 0
+      - name: GYROSCOPE_Y
+        id: 1
+      - name: GYROSCOPE_Z
+        id: 2
+  - type: single
+    name: ALTITUDE
+    id: 8
+    unit: "m"
+  - type: single
+    name: EST_ALTITUDE
+    id: 19
+    unit: "m"
+  - type: single
+    name: TEMP
+    id: 6
+    unit: "°C"
+  - type: single
+    name: PRESSURE
+    id: 7
+    unit: "hPa"
+  - type: group
+    name: MAGNETOMETER
+    id: 111
+    unit: "µT"
+    data:
+      - name: MAGNETOMETER_X
+        id: 9
+      - name: MAGNETOMETER_Y
+        id: 10
+      - name: MAGNETOMETER_Z
+        id: 11
+  - type: single
+    name: CYCLE_RATE
+    id: 13
+    unit: "Hz"
+  - type: single
+    name: STATE_CHANGE
+    id: 15
+    unit: "enum"
+  - type: single
+    name: BATT
+    id: 20
+    unit: "V"
+  - type: single
+    name: FLIGHT_ID
+    id: 16
+    unit: "id"

--- a/cure_ground/core/protocols/data_names/data_names_v03.yaml
+++ b/cure_ground/core/protocols/data_names/data_names_v03.yaml
@@ -11,7 +11,7 @@ data_names:
       - name: ACCELEROMETER_Z
         id: 2
   - type: group
-    name: ACCELEROMETGYROSCOPE_XER
+    name: GYROSCOPE
     id: 105
     unit: "°/s"
     data:
@@ -30,7 +30,7 @@ data_names:
     id: 19
     unit: "m"
   - type: single
-    name: TEMP
+    name: TEMPERATURE
     id: 6
     unit: "°C"
   - type: single


### PR DESCRIPTION
New format is as consistent as possible with the old one. The change includes a new variable for each element in the list called "type", which is either "group" or "single". "single" elements look the same as they do in data_names_v02.yml. "group" elements have a name for their group, their ID, their unit for each datum, and then a list called "data" that gives the ids for each individual element that composes the group. THE ORDER OF THE LIST DENOTES THE ORDER THAT THE GROUP IS SENT IN.